### PR TITLE
fix: resolve dedicated server crash, pathfinding logic, audio fallback NPE, and player vision softlock

### DIFF
--- a/src/main/java/dev/omialien/revervoxmod/RevervoxMod.java
+++ b/src/main/java/dev/omialien/revervoxmod/RevervoxMod.java
@@ -93,7 +93,12 @@ public class RevervoxMod {
         if(audio == null){
             audio = RevervoxMod.AUDIOS.getRandomAudio(false);
         }
-        if(audio == null){ return; }
+        if(audio == null){
+            if (player instanceof ServerPlayer serverPlayer) {
+                PlayerVisibilityUtil.restorePlayerVision(serverPlayer);
+            }
+            return;
+        }
         IRecordedAudio finalAudio = audio;
         TASKS.schedule(() -> AudioPlayingUtil.playFromEntity(finalAudio, revervox, RevervoxMod.MOD_ID), 5);// small delay in case it disappears instantly
         revervox.setPos(revervoxPos.x, revervoxPos.y, revervoxPos.z);

--- a/src/main/java/dev/omialien/revervoxmod/entity/ai/MMWalkNodeProcessor.java
+++ b/src/main/java/dev/omialien/revervoxmod/entity/ai/MMWalkNodeProcessor.java
@@ -46,7 +46,8 @@ public class MMWalkNodeProcessor extends WalkNodeEvaluator {
                             pos, CollisionContext.empty()
                     ) != Shapes.empty()
                             )) {
-                pos.setY(y--);
+                pos.setY(--y);
+                blockState = this.level.getBlockState(pos);
             }
             y++;
         }

--- a/src/main/java/dev/omialien/revervoxmod/entity/custom/RevervoxFakeBatEntity.java
+++ b/src/main/java/dev/omialien/revervoxmod/entity/custom/RevervoxFakeBatEntity.java
@@ -2,6 +2,8 @@ package dev.omialien.revervoxmod.entity.custom;
 
 import de.maxhenkel.voicechat.api.VoicechatServerApi;
 import dev.omialien.revervoxmod.RevervoxMod;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
 import dev.omialien.revervoxmod.networking.packets.SoundInstancePacket;
 import dev.omialien.revervoxmod.particle.ParticleManager;
 import dev.omialien.revervoxmod.registries.ParticleRegistry;
@@ -197,6 +199,7 @@ public class RevervoxFakeBatEntity extends FlyingMob implements GeoEntity {
     }
 
     @Override
+    @OnlyIn(Dist.CLIENT)
     public boolean isInvisible() {
         if(level().isClientSide){
             if(Minecraft.getInstance().player != null){

--- a/src/main/java/dev/omialien/revervoxmod/voicechat/AudioStorage.java
+++ b/src/main/java/dev/omialien/revervoxmod/voicechat/AudioStorage.java
@@ -50,7 +50,7 @@ public class AudioStorage {
         if ( audio != null ) {
             return audio;
         }
-        return this.getRandomAudio(player, remove);
+        return this.getRandomAudio(remove);
     }
 
     public IRecordedAudio getRandomAudio(Predicate<UUID> includePlayer, boolean remove){


### PR DESCRIPTION
This PR addresses four critical bugs affecting server stability, entity AI pathfinding, event lifecycle state, and audio fallback handling.

---

### 1. Fix Dedicated Server Crash (`RevervoxFakeBatEntity`)
* **Bug:** `isInvisible()` directly referenced `net.minecraft.client.Minecraft` inside common entity code. When entity removal or tick logic executed on a dedicated server, this triggered a fatal `NoClassDefFoundError`.
* **Fix:** Annotated `isInvisible()` with `@OnlyIn(Dist.CLIENT)` to ensure client-only class references are stripped in dedicated server environments.

---

### 2. Fix NPE on Missing Player Audio (`AudioStorage`)
* **Bug:** `getRandomAudioAnyFallback()` invoked `getRandomAudio(player, remove)` in its fallback branch instead of `getRandomAudio(remove)`. If the target player had no recordings, the method returned `null`, causing a `NullPointerException` during `awardKillScore` execution.
* **Fix:** Updated the fallback path to call `getRandomAudio(remove)`, correctly returning any available global audio clip when player-specific audio is missing.

---

### 3. Fix Permanent Player Vision Isolation (`RevervoxMod`)
* **Bug:** `triggerRevervoxBehindEvent` hides surrounding players via `PlayerVisibilityUtil.isolatePlayer`. If `SpawnFakeRevervox` aborted due to missing audio (`audio == null`), it returned without restoring visibility—permanently softlocking the player's ability to see others until re-logging.
* **Fix:** Added a call to `PlayerVisibilityUtil.restorePlayerVision` prior to returning early when no audio is present.

---

### 4. Fix Airborne Pathfinding Ground Scan (`MMWalkNodeProcessor`)
* **Bug:** `getStart()` decremented `y` in a loop checking `blockState.isAir()`, but never re-fetched `blockState` for decremented positions. When an entity was airborne, the loop evaluated the initial air state continuously until reaching Y=0, producing invalid path nodes at Y=1.
* **Fix:** Re-evaluated `blockState` for each decremented position inside the loop so ground detection stops at the first solid block beneath the entity.